### PR TITLE
Fix Conflict between Neutron and WPCS

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -36,5 +36,9 @@
 		<exclude-pattern>./</exclude-pattern>
 	</rule>
 
+	<!-- Conflict with WordPress standard. -->
+	<rule ref="NeutronStandard.Arrays.DisallowLongformArray.LongformArray">
+		<exclude-pattern>./</exclude-pattern>
+	</rule>
 
 </ruleset>


### PR DESCRIPTION
The short array syntax is now disallowed in WordPress coding standards, but is required by Neutron. This disables the Neutron rule.